### PR TITLE
Added authoritative summaries for Logo; added related subdirs

### DIFF
--- a/doc/Assests/Fonts/Placeholder.txt
+++ b/doc/Assests/Fonts/Placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file so that Git commits dir structure.

--- a/doc/Assests/README.md
+++ b/doc/Assests/README.md
@@ -1,0 +1,48 @@
+# Budget First UI Assests Criteria
+
+## Table of Contents
+
+(TODO: Run a script to generate this later)
+
+## Overview
+This is a doc to harden the UI of the BudgetFirst project while the architecture and frameworks are hardened and chosen. To engage with other aspects of the BudgetFirst project, please check [/r/budgetfirst](https://www.reddit.com/r/budgetfirst/) for community forums, the [Google Group](https://groups.google.com/forum/#!forum/budget-first) to request to join the contributor discussions on [Slack](https://budgetfirst.slack.com) and project management on [Taiga](https://tree.taiga.io/project/urbanhusky-budget-first/), or the eventual code repository on [GitHub](https://github.com/BudgetFirst/BudgetFirst)!
+
+
+## Assets Documentation Hardening Process
+
+The following is a work in progress and will be carried out in several steps:
+1. Note primary dos/do nots as given by platform authorities (Apple, Google, etc)
+2. Condense primary list into a universal set of mandatory guidelines
+3. Create secondary criteria list driven by contributor conversation (e.g. logo themes)
+
+### Assets
+
+Assets (e.g. fonts) in general should follow the guidelines as set by the authority that manages the device in question. This ensures a 'native' feel to the app.
+
+#### General Authoritative Guidelines
+
+##### Android
+
+###### Do's
+
+###### Do Not's
+
+##### iOS / OS X
+
+###### Do's
+
+###### Do Not's
+
+##### Windows
+
+###### Do's
+
+###### Do Not's
+
+#### General Contributor Consensus Guidelines
+
+###### Do's
+
+###### Do Not's
+
+## Platform Authority UI Guideline Documentation/Resources

--- a/doc/Logo/Mobile/Placeholder.txt
+++ b/doc/Logo/Mobile/Placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file so that Git commits dir structure.

--- a/doc/Logo/PC/Placeholder.txt
+++ b/doc/Logo/PC/Placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file so that Git commits dir structure.

--- a/doc/Logo/README.md
+++ b/doc/Logo/README.md
@@ -1,0 +1,101 @@
+# Budget First UI Logo Criteria
+
+## Table of Contents
+
+(TODO: Run a script to generate this later)
+
+## Overview
+This is a doc to harden the UI of the BudgetFirst project while the architecture and frameworks are hardened and chosen. To engage with other aspects of the BudgetFirst project, please check [/r/budgetfirst](https://www.reddit.com/r/budgetfirst/) for community forums, the [Google Group](https://groups.google.com/forum/#!forum/budget-first) to request to join the contributor discussions on [Slack](https://budgetfirst.slack.com) and project management on [Taiga](https://tree.taiga.io/project/urbanhusky-budget-first/), or the eventual code repository on [GitHub](https://github.com/BudgetFirst/BudgetFirst)!
+
+
+## Logo Documentation Hardening Process
+
+The following is a work in progress and will be carried out in several steps:
+1. Note primary dos/do nots as given by platform authorities (Apple, Google, etc)
+2. Condense primary list into a universal set of mandatory guidelines
+3. Create secondary criteria list driven by contributor conversation (e.g. logo themes)
+
+### Logo
+
+The logo should be designed to be platform ambiguous. In other words the logo appearance should be the same across PC and mobile platforms with little to no alternations across said platforms.
+
+#### General Authoritative Guidelines
+
+##### Android
+
+###### Do's
+* Color elements are flush to the paper’s surface
+* Layer paper elements to create depth, having edges and shadows
+* Elevate a key material element atop a simple background silhouette focuses attention to the center
+* Score material elements with the illusion of depth without losing their geometric form. Scores should be centered on symmetrical shapes
+* Folded material elements are skewed, having greater dimension
+* Overlapped material elements create unique silhouettes. All elements, edges, and shadows are confined to the interior of the silhouette
+* Accordion folded material elements are adjoined by a connecting fold, used to add dimension to a single material element
+* Elements should remain in their geometric form, and not be skewed, rotated, bowed, warped, or bent.
+* Do use simple shapes for background silhouettes
+* Do use the correct and consistent human form at all times
+* Do use curved and straight edges for visual balance
+
+###### Do Not's
+* Don’t embellish color elements with any edges or shadows
+* Don't have too many overlapping surfaces
+* Don’t crop elevated material elements within another shape
+* Don’t use multiple scores, or position a score off-center
+* Spot colors should be avoided, so as to avoid altering or misrepresenting key elements
+* Don’t exceed more than two overlaps. Having too many complicates the icon and lacks focus
+* Don’t exceed more than two accordion folds. Having too many complicates the icon and lacks focus
+* Product icons should never be distorted or transformed
+* Don’t use complicated shapes for background silhouettes
+* Don’t use an incorrect human form or add complex details
+* Don’t use circular arm terminals nor cropped arms
+
+##### iOS / OS X
+
+###### Do's
+* Use universal imagery that people will easily recognize
+ * For example, the Mail app icon uses an envelope
+* Embrace simplicity
+* Create an abstract interpretation of your app’s main idea
+* If you want to portray real substances, do it accurately
+* Make sure the app icon looks good on a variety of backgrounds
+* App icon should be opaque
+* Create different sizes of the app icon for different devices
+ * When iOS displays an app icon on the Home screen of a device, it automatically applies a mask that rounds the corners. Make sure your icon has 90° corners so it looks good after the mask is applied
+
+###### Do Not's
+* Avoid focusing on a secondary or obscure aspect of an element
+ * For example, the Mail app icon isn't a rural mailbox, a mail carrier’s bag, or a post office symbol
+* Avoid cramming lots of different images into your icon
+* Don't use a photo or screenshot in an app icon
+* Don’t just test your icon on a light or dark background
+* Avoid transparency
+* Don’t use iOS interface elements in your artwork
+* Don’t use replicas of Apple hardware products in your artwork
+* Don’t reuse iOS app icons in your interface
+
+##### Windows
+
+###### Do's
+* Curved lines are constructed from sections of a whole circle and should not be skewed unless needed to snap to the pixel grid
+* Use the following particular angles to ensure consistency. These lines can be combined, joined, rotated, and reflected in creating icons:
+ * 1:1 (45°)
+ * 1:2 (26.57° [vertical], 63.43° [horizontal])
+ * 1:3 (18.43° [vertical], 71.57° [horizontal])
+ * 1:4 (14.04° [vertical], 75.96° [horizontal])
+
+#### General Contributor Consensus Guidelines
+
+###### Do's
+* Clear outline/silhouette
+* Clear connection between small (16x16) to medium sized logos (i.e. app logo) with the possibility for larger designs based on it
+
+###### Do Not's
+* Avoid any locale or region specific lettering (i.e. no $, € etc. symbols)
+* Avoid elements that are looked down upon such piggy banks due to bad symbolism of pigs in some cultures
+
+## Platform Authority UI Guideline Documentation/Resources
+
+* [Android](https://www.google.com/design/spec/style/)
+* [iOS](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/)
+* [OSX](https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/)
+* [Windows](https://developer.microsoft.com/en-us/windows/design/style)

--- a/doc/Wireframes/Mobile/Android/Placeholder.txt
+++ b/doc/Wireframes/Mobile/Android/Placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file so that Git commits dir structure.

--- a/doc/Wireframes/Mobile/Windows 10/Placeholder.txt
+++ b/doc/Wireframes/Mobile/Windows 10/Placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file so that Git commits dir structure.

--- a/doc/Wireframes/Mobile/iOS/Placeholder.txt
+++ b/doc/Wireframes/Mobile/iOS/Placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file so that Git commits dir structure.

--- a/doc/Wireframes/PC/Linux/Placeholder.txt
+++ b/doc/Wireframes/PC/Linux/Placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file so that Git commits dir structure.

--- a/doc/Wireframes/PC/OSX/Placeholder.txt
+++ b/doc/Wireframes/PC/OSX/Placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file so that Git commits dir structure.

--- a/doc/Wireframes/PC/Windows/Placeholder.txt
+++ b/doc/Wireframes/PC/Windows/Placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder file so that Git commits dir structure.

--- a/doc/Wireframes/README.md
+++ b/doc/Wireframes/README.md
@@ -1,0 +1,53 @@
+# Budget First UI Wireframe Criteria
+
+## Table of Contents
+
+(TODO: Run a script to generate this later)
+
+## Overview
+This is a doc to harden the UI of the BudgetFirst project while the architecture and frameworks are hardened and chosen. To engage with other aspects of the BudgetFirst project, please check [/r/budgetfirst](https://www.reddit.com/r/budgetfirst/) for community forums, the [Google Group](https://groups.google.com/forum/#!forum/budget-first) to request to join the contributor discussions on [Slack](https://budgetfirst.slack.com) and project management on [Taiga](https://tree.taiga.io/project/urbanhusky-budget-first/), or the eventual code repository on [GitHub](https://github.com/BudgetFirst/BudgetFirst)!
+
+
+## Wireframes Documentation Hardening Process
+
+The following is a work in progress and will be carried out in several steps:
+1. Note primary dos/do nots as given by platform authorities (Apple, Google, etc)
+2. Condense primary list into a universal set of mandatory guidelines
+3. Create secondary criteria list driven by contributor conversation (e.g. logo themes)
+
+### Wireframe
+
+Wireframes should follow the design and appearance guidelines as set by the authority that manages the device in question. This ensures a 'native' feel to the app. Workflows should be as user friendly and avoid complexity to allow new users to quickly pick up how they can do what they need to do without thinking.
+
+#### General Authoritative Guidelines
+
+##### Android
+
+###### Do's
+
+###### Do Not's
+
+##### iOS / OS X
+
+###### Do's
+
+###### Do Not's
+
+##### Windows
+
+###### Do's
+
+###### Do Not's
+
+#### General Contributor Consensus Guidelines
+
+###### Do's
+
+###### Do Not's
+
+## Platform Authority UI Guideline Documentation/Resources
+
+* [Android](https://www.google.com/design/spec/style/)
+* [iOS](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/)
+* [OSX](https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/)
+* [Windows](https://developer.microsoft.com/en-us/windows/design/style)


### PR DESCRIPTION
Still need to condense into one list, repeat the process for wireframes
(might avoid since there's too many UI elements in any given wireframe
and just defer to Microsoft, Google, and Apple design guideline
websites) and font